### PR TITLE
Implement PPO trading bot with Liquid Neural Network

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from datetime import datetime, timedelta
+import yfinance as yf
+
+
+def load_data(tickers, years=5):
+    end = datetime.today()
+    start = end - timedelta(days=365 * years)
+    data = {}
+    for ticker in tickers:
+        df = yf.download(ticker, start=start, end=end, progress=False, auto_adjust=True)
+        if df.empty:
+            continue
+        df['MA50'] = df['Close'].rolling(50).mean()
+        df['MA150'] = df['Close'].rolling(150).mean()
+        df['MA200'] = df['Close'].rolling(200).mean()
+        df['52w_high'] = df['Close'].rolling(252).max()
+        df['52w_low'] = df['Close'].rolling(252).min()
+        df['VOL20'] = df['Volume'].rolling(20).mean()
+        df.dropna(inplace=True)
+        data[ticker] = df
+    return data

--- a/main.py
+++ b/main.py
@@ -1,0 +1,37 @@
+import argparse
+import os
+from data_loader import load_data
+from model import train_agent
+from signals import generate_signals
+from notifier import send_email
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--timesteps', type=int, default=1000)
+    parser.add_argument('--no-train', action='store_true')
+    args = parser.parse_args()
+
+    tickers = ['AAPL', 'MSFT', 'NVDA', 'SPY']
+    data = load_data(tickers)
+    if 'AAPL' not in data:
+        print('Data download failed')
+        return
+    if args.no_train and os.path.exists('ppo_minervini.zip'):
+        from stable_baselines3 import PPO
+        agent = PPO.load('ppo_minervini.zip')
+    else:
+        agent = train_agent(data['AAPL'], timesteps=args.timesteps)
+        agent.save('ppo_minervini.zip')
+    signals = generate_signals(agent, data)
+    for s in signals:
+        print(s)
+    user = os.getenv('GMAIL_USER')
+    password = os.getenv('GMAIL_PASS')
+    to = os.getenv('TO_EMAIL')
+    if user and password and to:
+        send_email(signals, user, password, to)
+
+
+if __name__ == '__main__':
+    main()

--- a/model.py
+++ b/model.py
@@ -1,0 +1,98 @@
+import numpy as np
+import torch
+import torch.nn as nn
+import gym
+from stable_baselines3 import PPO
+from stable_baselines3.common.policies import ActorCriticPolicy
+from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
+
+
+class LiquidCell(nn.Module):
+    def __init__(self, input_size, hidden_size):
+        super().__init__()
+        self.fc = nn.Linear(input_size + hidden_size, hidden_size)
+
+    def forward(self, x, h):
+        combined = torch.cat([x, h], dim=-1)
+        u = torch.tanh(self.fc(combined))
+        dh = u - h
+        h = h + dh * torch.sigmoid(u)
+        return h
+
+
+class LiquidNetwork(nn.Module):
+    def __init__(self, input_size, hidden_size):
+        super().__init__()
+        self.cell = LiquidCell(input_size, hidden_size)
+        self.hidden_size = hidden_size
+
+    def forward(self, x):
+        h = torch.zeros(x.size(0), self.hidden_size, device=x.device)
+        for t in range(x.size(1)):
+            h = self.cell(x[:, t, :], h)
+        return h
+
+
+class LNNExtractor(BaseFeaturesExtractor):
+    def __init__(self, observation_space, seq_len=30, features_dim=64):
+        self.seq_len = seq_len
+        super().__init__(observation_space, features_dim)
+        self.lnn = LiquidNetwork(2, features_dim)
+
+    def forward(self, observations):
+        batch = observations.view(observations.size(0), self.seq_len, 2)
+        h = self.lnn(batch)
+        return h
+
+
+class MinerviniEnv(gym.Env):
+    def __init__(self, df):
+        super().__init__()
+        self.df = df
+        self.features = df[['Close', 'Volume']]
+        self.returns = self.features['Close'].pct_change().fillna(0)
+        self.vol_ratio = (self.features['Volume'] / self.features['Volume'].rolling(20).mean()).fillna(1)
+        self.seq_len = 30
+        self.action_space = gym.spaces.Discrete(3)
+        self.observation_space = gym.spaces.Box(low=-np.inf, high=np.inf, shape=(self.seq_len*2,), dtype=np.float32)
+        self.reset()
+
+    def _get_obs(self):
+        start = self.step_index - self.seq_len
+        seq_ret = self.returns.iloc[start:self.step_index].values
+        seq_vol = self.vol_ratio.iloc[start:self.step_index].values
+        obs = np.stack([seq_ret, seq_vol], axis=1).astype(np.float32).flatten()
+        return obs
+
+    def reset(self):
+        self.step_index = self.seq_len
+        self.position = 0
+        self.entry_price = 0.0
+        return self._get_obs()
+
+    def step(self, action):
+        reward = 0.0
+        done = False
+        price = self.features['Close'].iloc[self.step_index]
+        ma50 = self.df['MA50'].iloc[self.step_index]
+        if action == 1 and self.position == 0:
+            self.position = 1
+            self.entry_price = price
+        elif action == 2 and self.position == 1:
+            reward = (price - self.entry_price) / self.entry_price
+            self.position = 0
+        if self.position == 1 and price < ma50:
+            reward -= 1.0
+            self.position = 0
+        self.step_index += 1
+        if self.step_index >= len(self.df):
+            done = True
+        return self._get_obs(), reward, done, {}
+
+
+def train_agent(df, timesteps=10000):
+    env = MinerviniEnv(df)
+    policy_kwargs = dict(features_extractor_class=LNNExtractor, features_extractor_kwargs=dict(seq_len=30, features_dim=64))
+    model = PPO('MlpPolicy', env, policy_kwargs=policy_kwargs, verbose=0)
+    model.learn(total_timesteps=timesteps)
+    return model

--- a/notifier.py
+++ b/notifier.py
@@ -1,0 +1,18 @@
+import smtplib
+from email.mime.text import MIMEText
+from typing import List, Dict
+
+
+def send_email(signals: List[Dict[str, str]], user: str, password: str, to: str):
+    body_lines = []
+    for s in signals:
+        rules_met = ', '.join([k for k, v in s['rules'].items() if v])
+        body_lines.append(f"{s['ticker']}: {s['action']} (conf={s['confidence']:.2f}) rules: {rules_met}")
+    body = '\n'.join(body_lines)
+    msg = MIMEText(body)
+    msg['Subject'] = 'Daily Trading Signals'
+    msg['From'] = user
+    msg['To'] = to
+    with smtplib.SMTP_SSL('smtp.gmail.com', 465) as smtp:
+        smtp.login(user, password)
+        smtp.sendmail(user, [to], msg.as_string())

--- a/signals.py
+++ b/signals.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pandas as pd
+from typing import Dict, List
+from model import MinerviniEnv
+
+
+def compute_rs_ranks(data: Dict[str, pd.DataFrame]) -> Dict[str, float]:
+    momentum = {}
+    for ticker, df in data.items():
+        if len(df) < 130:
+            continue
+        momentum[ticker] = df['Close'].iloc[-1] / df['Close'].iloc[-125] - 1
+    ranks = {}
+    if momentum:
+        series = pd.Series(momentum)
+        ranks = (series.rank(pct=True) - 0).to_dict()
+    return ranks
+
+
+def apply_minervini_rules(df: pd.DataFrame, market_df: pd.DataFrame, rs_rank: float) -> Dict[str, bool]:
+    price = df['Close'].iloc[-1]
+    ma50 = df['MA50'].iloc[-1]
+    ma150 = df['MA150'].iloc[-1]
+    ma200 = df['MA200'].iloc[-1]
+    rules = {}
+    rules['ma_alignment'] = price > ma50 > ma150 > ma200 and ma150 > ma200 and ma200 > df['MA200'].iloc[-20]
+    rules['52w_proximity'] = price >= 1.25 * df['52w_low'].iloc[-1] and price <= 0.75 * df['52w_high'].iloc[-1]
+    rules['rs'] = rs_rank >= 0.6
+    rules['volume_surge'] = df['Volume'].iloc[-1] >= 1.5 * df['VOL20'].iloc[-1]
+    rules['trend'] = price > df['Close'].iloc[-30]
+    rules['market'] = market_df['Close'].iloc[-1] > market_df['MA200'].iloc[-1]
+    return rules
+
+
+def latest_observation(df: pd.DataFrame) -> np.ndarray:
+    env = MinerviniEnv(df)
+    env.step_index = len(df)
+    return env._get_obs()
+
+
+def generate_signals(agent, data: Dict[str, pd.DataFrame]) -> List[Dict[str, str]]:
+    market_df = data.get('SPY')
+    rs_ranks = compute_rs_ranks(data)
+    signals = []
+    for ticker, df in data.items():
+        if ticker == 'SPY':
+            continue
+        obs = latest_observation(df)
+        obs_tensor = agent.policy.obs_to_tensor(obs)[0]
+        dist = agent.policy.get_distribution(obs_tensor)
+        probs = dist.distribution.probs.detach().cpu().numpy()[0]
+        action = np.argmax(probs)
+        rules = apply_minervini_rules(df, market_df, rs_ranks.get(ticker, 0))
+        all_rules = all(rules.values())
+        price = df['Close'].iloc[-1]
+        if action == 1 and all_rules:
+            decision = 'Buy'
+        elif price < df['MA50'].iloc[-1]:
+            decision = 'Sell'
+        else:
+            decision = 'Hold'
+        signals.append({
+            'ticker': ticker,
+            'action': decision,
+            'confidence': float(probs[action]),
+            'rules': rules
+        })
+    return signals


### PR DESCRIPTION
## Summary
- refactor into modular files with yfinance data loader for AAPL, MSFT, NVDA, SPY
- add Liquid Neural Network PPO model and MinerviniEnv with risk penalties
- generate Minervini rule-based signals and optional Gmail notifications

## Testing
- `python -m py_compile data_loader.py model.py signals.py notifier.py main.py`
- `python main.py --timesteps 1` *(fails: Failed to get ticker due to 403 CONNECT tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68a09ebd2688832aab1ee5b67879981a